### PR TITLE
Add showHint option to override `first` value

### DIFF
--- a/addon/hint/show-hint.js
+++ b/addon/hint/show-hint.js
@@ -43,7 +43,10 @@
     if (!completion.options.hint) return;
 
     CodeMirror.signal(this, "startCompletion", this);
-    completion.update(true);
+    var first = true;
+    if (options.firstOverride !== undefined)
+      first = options.firstOverride;
+    completion.update(first);
   });
 
   function Completion(cm, options) {


### PR DESCRIPTION
Passing first=true to `update` makes sense when the user is explicitly
requesting completions, so that if there is only one item in the list it
can complete their text.

It makes less sense if the editor is configured to show hints as often
as possible. `options.firstOverride` provides a way for such an editor
to prevent auto-completion when all we want is to show the list as the
user types, even if there is only one item.
